### PR TITLE
Encode the service name as base 16.

### DIFF
--- a/asyncy/Kubernetes.py
+++ b/asyncy/Kubernetes.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 import asyncio
+import base64
 import json
 import ssl
 import time
@@ -479,7 +480,8 @@ class Kubernetes:
                     'metadata': {
                         'labels': {
                             'app': container_name,
-                            'service-name': service_name,
+                            'b16-service-name':
+                                base64.b16encode(service_name.encode()),
                             'logstash-enabled': 'true'
                         }
                     },

--- a/tests/unit/Kubernetes.py
+++ b/tests/unit/Kubernetes.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 import asyncio
+import base64
 import json
 import ssl
 import time
@@ -582,7 +583,7 @@ async def test_create_deployment(patch, async_mock, story):
                     'labels': {
                         'app': container_name,
                         'logstash-enabled': 'true',
-                        'service-name': 'alpine'
+                        'b16-service-name': base64.b16encode('alpine'.encode())
                     }
                 },
                 'spec': {


### PR DESCRIPTION
Why? Because k8s doesn't like / in the value of a label.