### PR TITLE
Set -preview=globals for all integration tests

### DIFF
--- a/tests/integration/processing/Lexicon.py
+++ b/tests/integration/processing/Lexicon.py
@@ -605,7 +605,7 @@ async def run_test_case_in_suite(suite: TestSuite, case: TestCase, logger):
     if case.prepend is not None:
         all_lines = case.prepend + '\n' + all_lines
 
-    story = storyscript.Api.loads(all_lines)
+    story = storyscript.Api.loads(all_lines, features={'globals': True})
     errors = story.errors()
     if len(errors) > 0:
         print(f'Failed to compile the following story:'


### PR DESCRIPTION
Counter-part of https://github.com/storyscript/storyscript/pull/905 for the engine.

tl;dr: the engine currently doesn't support globals. Thus, the Storyscript compiler will error. However, as we want to implement this feature soon (and it makes the test suites so much nicer), Storyscript already comes with a `-preview=globals` switch. It can be activated via the API as shown below.

This will be required for SS 0.20.