### PR TITLE
Fix for ServiceOutputValidator

### DIFF
--- a/asyncy/processing/Services.py
+++ b/asyncy/processing/Services.py
@@ -463,7 +463,7 @@ class Services:
     @classmethod
     def parse_output(cls, command_conf: dict, raw_output, story,
                      line, content_type: str):
-        output = command_conf.get('output', {})
+        output = command_conf.get('output', None)
         if output is None:
             return raw_output
         t = output.get('type', None)

--- a/asyncy/processing/Services.py
+++ b/asyncy/processing/Services.py
@@ -464,7 +464,9 @@ class Services:
     def parse_output(cls, command_conf: dict, raw_output, story,
                      line, content_type: str):
         output = command_conf.get('output', {})
-        t = output.get('type')
+        if output is None:
+            return raw_output
+        t = output.get('type', None)
         if t is None or t == 'any':
             return raw_output  # We don't know what it is, return raw bytes.
 

--- a/asyncy/processing/Services.py
+++ b/asyncy/processing/Services.py
@@ -444,8 +444,9 @@ class Services:
                         story=story, line=line)
 
                 expected_service_output = command_conf.get('output')
-                ServiceOutputValidator.raise_if_invalid(
-                    expected_service_output, body, chain)
+                if expected_service_output is not None:
+                    ServiceOutputValidator.raise_if_invalid(
+                        expected_service_output, body, chain)
                 return body
             else:
                 return cls.parse_output(command_conf, response.body,

--- a/tests/unit/processing/Services.py
+++ b/tests/unit/processing/Services.py
@@ -418,8 +418,8 @@ def test_parse_output(output_type, story):
         actual_input = f'true'
         expected_output = True
     elif output_type is None:
-        actual_input = b'empty'
-        expected_output = b'empty'
+        actual_input = None
+        expected_output = None
     elif output_type == 'any':
         actual_input = b'empty'
         expected_output = b'empty'


### PR DESCRIPTION
This fixes the issue we discussed previously.

e.g.
```
runtime: An exception has occurred:
Failed to execute line: 'NoneType' object has no attribute 'get'
    at line 2: when client listen path: "/status" as request (in src/health.story)
    at line 4: redis get key: "__health_key_non_existent_ok" (in src/health.story)
```