### PR TITLE
Disable service usage recording temporarily

### DIFF
--- a/asyncy/Apps.py
+++ b/asyncy/Apps.py
@@ -173,10 +173,11 @@ class Apps:
                                             daemon=True)
         release_listener.start()
 
-        usage_recorder = threading.Thread(target=ServiceUsage.start_recording,
-                                          args=[config, glogger, loop],
-                                          daemon=True)
-        usage_recorder.start()
+        # usage_recorder = threading.Thread(
+        #     target=ServiceUsage.start_recording,
+        #     args=[config, glogger, loop],
+        #     daemon=True)
+        # usage_recorder.start()
 
         await cls.reload_apps(config, glogger)
 

--- a/tests/unit/Apps.py
+++ b/tests/unit/Apps.py
@@ -143,9 +143,9 @@ async def test_init_all(patch, magic, async_mock, config, logger, db):
         mock.call(target=Apps.listen_to_releases,
                   args=[config, logger, loop],
                   daemon=True),
-        mock.call(target=ServiceUsage.start_recording,
-                  args=[config, logger, loop],
-                  daemon=True),
+        # mock.call(target=ServiceUsage.start_recording,
+        #           args=[config, logger, loop],
+        #           daemon=True),
     ]
     Thread.start.assert_called()
 


### PR DESCRIPTION
Disabling since there's an unhandled case for k8s, when the pod label value becomes longer than 63 characters.