### PR TITLE
Add global context to App

### DIFF
--- a/asyncy/App.py
+++ b/asyncy/App.py
@@ -79,6 +79,7 @@ class App:
             'hostname': f'{self.app_dns}.{self.config.APP_DOMAIN}',
             'version': self.version
         }
+        self.global_context = {}
 
     def image_pull_policy(self):
         if self.always_pull_images is True:
@@ -173,7 +174,8 @@ class App:
         register with the gateway, and queue cron jobs.
         """
         for story_name in self.entrypoint:
-            await Stories.run(self, self.logger, story_name)
+            await Stories.run(self, self.logger, story_name,
+                              context=self.global_context)
 
     def add_subscription(self, sub_id: str,
                          streaming_service: StreamingService,

--- a/asyncy/http_handlers/StoryEventHandler.py
+++ b/asyncy/http_handlers/StoryEventHandler.py
@@ -30,6 +30,7 @@ class StoryEventHandler(BaseHandler):
         }
 
         app = Apps.get(app_id)
+        context.update(app.global_context)
 
         for key in self.get_req().files.keys():
             if key == CLOUD_EVENTS_FILE_KEY:


### PR DESCRIPTION
Currently, you cannot access global variables due to the context not being carried down to any child execution. For example, within the HTTP Service, we trigger handlers with a fresh context.

```
context = {
    ContextConstants.service_event: event_body,
    ContextConstants.server_io_loop: io_loop,
    ContextConstants.server_request: self
}
```

I simply define app.global_context, and pass it along to Stories.run. This may not be ideal, but it solves the problem where something like the code below returns None:

```
response = "Hello World"
http server as client
  when client listen method:"get" path:"/" as r
    log info msg: "{response}"
    r write content: response
```